### PR TITLE
Username can't contain whitespace

### DIFF
--- a/src/main/java/com/newts/newtapp/api/application/user/Create.java
+++ b/src/main/java/com/newts/newtapp/api/application/user/Create.java
@@ -3,6 +3,7 @@ package com.newts.newtapp.api.application.user;
 import com.newts.newtapp.api.gateways.UserRepository;
 import com.newts.newtapp.api.application.*;
 import com.newts.newtapp.api.errors.InvalidPassword;
+import com.newts.newtapp.api.errors.InvalidUsername;
 import com.newts.newtapp.api.errors.UserAlreadyExists;
 import com.newts.newtapp.entities.User;
 import java.util.ArrayList;
@@ -13,15 +14,20 @@ public class Create extends UserInteractor<Void,Exception> {
      * Initialize a new Create interactor with given UserRepository.
      * @param repository    UserRepository to access user data by
      */
-    public Create(UserRepository repository) { super(repository); }
+    public Create(UserRepository repository) {
+        super(repository);
+    }
 
     /**
      * Accepts a Create request.
      * @param request   a request stored as a RequestModel
      */
     @Override
-    public Void request(RequestModel request) throws InvalidPassword, UserAlreadyExists {
+    public Void request(RequestModel request) throws InvalidPassword, InvalidUsername, UserAlreadyExists {
         String username = (String) request.get(RequestField.USERNAME);
+        if (username.contains(" ")) {
+            throw new InvalidUsername();
+        }
         if (userRepository.findByUsernameIgnoreCase(username).isPresent()) {
             throw new UserAlreadyExists();
         }

--- a/src/main/java/com/newts/newtapp/api/errors/InvalidUsername.java
+++ b/src/main/java/com/newts/newtapp/api/errors/InvalidUsername.java
@@ -1,0 +1,8 @@
+package com.newts.newtapp.api.errors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_ACCEPTABLE)
+public class InvalidUsername extends Exception {
+}


### PR DESCRIPTION
Modified Create user interactor to require usernames to not contain whitespace

and added a following InvalidUsername error.